### PR TITLE
fix the mismatch about icon name between local and remote

### DIFF
--- a/app/controllers/bios_controller.rb
+++ b/app/controllers/bios_controller.rb
@@ -32,7 +32,7 @@ class BiosController < ApplicationController
   private
 
   def bio_params
-    params.require(:bio).permit(:title, :content, :icon, :iconLink)
+    params.require(:bio).permit(:title, :content, :icon) #, :iconCloud
   end
 
 end

--- a/app/models/_bio.rb
+++ b/app/models/_bio.rb
@@ -1,7 +1,7 @@
 class Bio < ApplicationRecord
-  # has_one_attached :icon
+  # has_one_attached :iconCloud
   validates :title, presence: true, length: { maximum: 24 }
   validates :content, presence: true, length: { maximum: 250 }
-  validates :iconLink, presence: true,
+  validates :icon, presence: true,
                    format: { with: /\w+.svg\z/, message: "Incorrect format for icon !" }
 end

--- a/app/views/bios/bio.html.erb
+++ b/app/views/bios/bio.html.erb
@@ -1,6 +1,6 @@
 <div>
 <div class="bio_card">
-      <div class="front" style="background-image: url(<%= image_path(iconLink) %>)">
+      <div class="front" style="background-image: url(<%= image_path(icon) %>)">
       </div>
       <div class="back">
         <div class="back-content middle">

--- a/app/views/bios/edit.html.erb
+++ b/app/views/bios/edit.html.erb
@@ -20,13 +20,13 @@
         </div>
 
         <div class="field">
-          <%= f.label :iconLink %><br />
-          <%= f.text_field :iconLink, autofocus: true, size:'30' %>
+          <%= f.label :icon %><br />
+          <%= f.text_field :icon, autofocus: true, size:'30' %>
         </div>
 
         <div class="field">
-          <%= f.label :icon, "Upload background picture" %><br />
-          <%= f.file_field :icon %>
+          <%= f.label :iconCloud, "Upload background picture" %><br />
+          <%= f.file_field :iconCloud %>
         </div>
 
         <div class="actions">

--- a/app/views/bios/new.html.erb
+++ b/app/views/bios/new.html.erb
@@ -20,13 +20,13 @@
         </div>
 
         <div class="field">
-          <%= f.label :iconLink %><br />
-          <%= f.text_field :iconLink, autofocus: true, autocomplete: "URL", size:'30' %>
+          <%= f.label :icon %><br />
+          <%= f.text_field :icon, autofocus: true, autocomplete: "URL", size:'30' %>
         </div>
 
         <div class="field">
-          <%= f.label :icon, "Upload background picture" %><br />
-          <%= f.file_field :icon %>
+          <%= f.label :iconCloud, "Upload background picture" %><br />
+          <%= f.file_field :iconCloud %>
         </div>
 
         <div class="actions">

--- a/app/views/pages/_bio_card.html.erb
+++ b/app/views/pages/_bio_card.html.erb
@@ -1,6 +1,6 @@
 <div>
 <div class="bio_card">
-      <div class="front" style="background-image: url(<%= image_path(bio.iconLink) %>)">
+      <div class="front" style="background-image: url(<%= image_path(bio.icon) %>)">
       </div>
       <div class="back">
         <div class="back-content middle">


### PR DESCRIPTION
Link to .svg in repo : Bio.icon on the remote was called Bio.iconLink in local
Link to cloud called iconCloud - not in use yet.